### PR TITLE
Fix BigQuery to_remote_storage

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -577,7 +577,7 @@ class BigQueryRetrievalJob(RetrievalJob):
         else:
             storage_client = StorageClient(project=self.client.project)
         bucket, prefix = self._gcs_path[len("gs://") :].split("/", 1)
-        prefix = prefix.rsplit("/", 1)[0]
+        # prefix = prefix.rsplit("/", 1)[0]
         if prefix.startswith("/"):
             prefix = prefix[1:]
 


### PR DESCRIPTION
**Context of PR:** this will fix the issue described in this PR: https://github.com/Ki-Insurance/feature-store/pull/829 - and the issue is explained with an example in that PR.

The issue as it currently is, is that when using BigQueryRetrievalJob.to_remote_storage, what that method returns is `results` which are the gs paths where there are now parquets. However, due to the line (that is now removed in this PR), when doing .list_blobs, the prefix that is passed to that is too short (i.e. is a couple of 'directories' up from where it should be), meaning that all other staged files that have been staged in a previous run are listed. This is not what you'd want.

e.g. see:


![Screenshot 2023-07-27 at 17 19 11](https://github.com/Ki-Insurance/feast/assets/131684659/2d4deca3-e924-4d5b-8ec6-ca4cbe08b002)

where you can see that the line that I have now commented out would shorten the prefix too much.

**Impact of this PR**: should be no impact, as thie BigQueryRetrievalJob.to_remote_storage is only used in BatchMaterializationEngines (and anyway, it is incorrect as is!)

**Summary of change:** you can see below, that there are a few parquets in that gcs bucket. The first attempt at getting results does not use the line that I commented out i.e. `prefix = prefix.rsplit("/", 1)[0]`, and the second approach still uses it. You can see the difference. Clearly, we do not want to use that line, so are commenting it out in this PR (could delete it if that is preferred)

![Screenshot 2023-07-27 at 17 36 19](https://github.com/Ki-Insurance/feast/assets/131684659/cee89bec-2ce0-4971-ad91-9661dc0929ba)

In case you want to try it out for yourself

```python
from google.cloud.storage import Client as StorageClient
storage_client = StorageClient()

s = 'gs://feast-materialize-dev/ki_feature_store/export/db8440f4-0f2e-4945-b7a2-631a2a03b664' # this will be self._gcs_path
bucket, prefix = s[len("gs://") :].split("/", 1)
# prefix = prefix.rsplit("/", 1)[0]  # this is the commented out line - can execute with and without and see the difference
if prefix.startswith("/"):
    prefix = prefix[1:]

blobs = storage_client.list_blobs(bucket, prefix=prefix)
results = []
for b in blobs:
    results.append(f"gs://{b.bucket.name}/{b.name}")

results
```
