### PR TITLE
Set lifetime for feast_tmp tables

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -503,7 +503,15 @@ class BigQueryRetrievalJob(RetrievalJob):
                 temp_dest_table = f"{tmp_dest['projectId']}.{tmp_dest['datasetId']}.{tmp_dest['tableId']}"
 
                 # persist temp table
-                sql = f"CREATE TABLE `{dest}` AS SELECT * FROM {temp_dest_table}"
+                # added expiration to table: https://stackoverflow.com/a/50227484
+                # as in bytewax materialization, these tables are not otherwise deleted
+                sql = f"""
+                    CREATE TABLE `{dest}`
+                    OPTIONS(
+                        expiration_timestamp=TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 3 DAY)
+                    )
+                    AS SELECT * FROM {temp_dest_table}
+                """
                 self._execute_query(sql, timeout=timeout)
 
             print(f"Done writing to '{dest}'.")


### PR DESCRIPTION
Adding lifetime to tables created via to_bigquery() call which is used in to_remote_storage() as in bytewax materialization, these tables are not otherwise deleted.

This should have no effect on anything else, as we only use to_bigquery() when calling to_remote_storage() which is used in the bytewax materialization when we save what needs to be materialized as parquets, first it goes into a BQ table