### PR TITLE
fix bytewax to 0.17.2

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -2108,7 +2108,8 @@ class FeatureStore:
 
             proto_values = [
                 python_values_to_proto_values(
-                    transformed_features_df[feature].values, feature_dtypes[feature].to_value_type()
+                    transformed_features_df[feature].values,
+                    feature_dtypes[feature].to_value_type(),
                 )
                 for feature in selected_subset
             ]

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ REDIS_REQUIRED = [
 
 AWS_REQUIRED = ["boto3>=1.17.0,<2", "docker>=5.0.2", "s3fs"]
 
-BYTEWAX_REQUIRED = ["bytewax==0.15.1", "docker>=5.0.2", "kubernetes<=20.13.0"]
+BYTEWAX_REQUIRED = ["bytewax==0.17.2"]
 
 SNOWFLAKE_REQUIRED = [
     "snowflake-connector-python[pandas]>=3,<4",

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ REQUIRED = [
     # Higher than 4.23.4 seems to cause a seg fault
     "protobuf<4.23.4,>3.20",
     "proto-plus>=1.20.0,<2",
-    "pyarrow>=4,<12",
+    "pyarrow>=4,<13",
     "pydantic>=1,<2",
     "pygments>=2.12.0,<3",
     "PyYAML>=5.4.0,<7",


### PR DESCRIPTION
fixes bytewax version to 0.17.2 inline with the updates to materialisation:
https://github.com/Ki-Insurance/feature-store/pull/1188/

updates pyarrow to work with ki-prefect-toolbox >3.1.0
