### PR TITLE
add ticks in select statement

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -522,7 +522,7 @@ class BigQueryRetrievalJob(RetrievalJob):
                     OPTIONS(
                         expiration_timestamp=TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 3 DAY)
                     )
-                    AS SELECT * FROM {temp_dest_table}
+                    AS SELECT * FROM `{temp_dest_table}`
                 """
                 self._execute_query(sql, timeout=timeout)
 

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -539,6 +539,7 @@ class BigQueryRetrievalJob(RetrievalJob):
     def _execute_query(
         self, query, job_config=None, timeout: Optional[int] = None
     ) -> Optional[bigquery.job.query.QueryJob]:
+        print(f"Executing query: {query}")
         bq_job = self.client.query(query, job_config=job_config)
 
         if job_config and job_config.dry_run:


### PR DESCRIPTION
adds ticks around table name which will *hopefully* fix the error seen in demo materialization here:
![image](https://github.com/Ki-Insurance/feast/assets/142818769/e9036036-0137-481b-9f46-cbfc346d9850)

have dug around in the infra set up for feature store demo, which all looks to be set up the same as uat, although this error isn't appearing in uat materialization (images are the same too)

seems bigquery has some odd functionality around dataset/table/project names https://stackoverflow.com/questions/70380199/bigquery-gives-missing-whitespace-error-when-creating-a-materialized-view
