### PR TITLE
DUG-348: fix for UI and seamless upgrade of on-demand features

### DIFF
--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -123,7 +123,7 @@ class OnDemandFeatureView(BaseFeatureView):
         )
 
         self.mode = mode.lower()
-
+        self.mode = "pandas" if not self.mode else self.mode
         if self.mode not in {"python", "pandas", "substrait"}:
             raise ValueError(
                 f"Unknown mode {self.mode}. OnDemandFeatureView only supports python or pandas UDFs and substrait."

--- a/sdk/python/feast/ui_server.py
+++ b/sdk/python/feast/ui_server.py
@@ -51,7 +51,7 @@ def get_app(
 
     async_refresh()
 
-    ui_dir_ref = importlib_resources.files(__name__) / "ui/build/"
+    ui_dir_ref = importlib_resources.files(__spec__.parent) / "ui/build/"  # type: ignore[name-defined]
     with importlib_resources.as_file(ui_dir_ref) as ui_dir:
         # Initialize with the projects-list.json file
         with ui_dir.joinpath("projects-list.json").open(mode="w") as f:


### PR DESCRIPTION
1. Manual copy of fix for UI issue introduced in 0.38 release of upstream
discussion: https://github.com/feast-dev/feast/issues/4241
fix: https://github.com/feast-dev/feast/pull/4248/files
2. quick amend to make upgrade on environments painless regarding on-demand features: when they are read during initial step of apply from registry, feast is unpacking protobuf with non-nullable string for mode parameter resulting in empty string which does not fall under standard default value provisions in python code, hence extra line

THIS CHANGE SHOULD BE DISCARDED IN NEXT UPDATE OF FEAST VERSION FROM UPSTREAM