### PR TITLE
removed entity tmp table deletion from bq as needed for executin sql …

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -285,12 +285,10 @@ class BigQueryOfflineStore(OfflineStore):
                 full_feature_names=full_feature_names,
             )
 
-            try:
-                yield query
-            finally:
-                # Asynchronously clean up the uploaded Bigquery table, which will expire
-                # if cleanup fails
-                client.delete_table(table=table_reference, not_found_ok=True)
+            # Removed table deletion as this makes it impossible to
+            # run offline feature retrieval SQL queries outside of this execution context.
+            # client.delete_table(table=table_reference, not_found_ok=True)
+            yield query
 
         return BigQueryRetrievalJob(
             query=query_generator,

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -96,16 +96,14 @@ def get_repo_files(repo_root: Path) -> List[Path]:
     # Sort repo_files to read them in the same order every time
     return sorted(repo_files)
 
+
 def _data_sources_equal(ds1: DataSource, ds2: DataSource) -> bool:
     """
-    Compare two (different) DataSource objects. This is a simplified version of the 
+    Compare two (different) DataSource objects. This is a simplified version of the
     original comparison logic, focusing on parent equality across common attributes and
     subclass identity.
     """
-    return (
-        type(ds1) == type(ds2)
-        and DataSource.__eq__(ds1, ds2)
-    )
+    return type(ds1) == type(ds2) and DataSource.__eq__(ds1, ds2)
 
 
 def parse_repo(repo_root: Path) -> RepoContents:
@@ -146,7 +144,8 @@ def parse_repo(repo_root: Path) -> RepoContents:
                     batch_source = obj.batch_source
 
                     if batch_source and not any(
-                        (_data_sources_equal(batch_source, ds)) for ds in res.data_sources
+                        (_data_sources_equal(batch_source, ds))
+                        for ds in res.data_sources
                     ):
                         res.data_sources.append(batch_source)
             if (
@@ -160,13 +159,18 @@ def parse_repo(repo_root: Path) -> RepoContents:
                 # Handle batch sources defined with feature views.
                 batch_source = obj.batch_source
                 assert batch_source
-                if not any((_data_sources_equal(batch_source, ds)) for ds in res.data_sources):
+                if not any(
+                    (_data_sources_equal(batch_source, ds)) for ds in res.data_sources
+                ):
                     res.data_sources.append(batch_source)
 
                 # Handle stream sources defined with feature views.
                 if obj.stream_source:
                     stream_source = obj.stream_source
-                    if not any((_data_sources_equal(stream_source, ds)) for ds in res.data_sources):
+                    if not any(
+                        (_data_sources_equal(stream_source, ds))
+                        for ds in res.data_sources
+                    ):
                         res.data_sources.append(stream_source)
             elif isinstance(obj, StreamFeatureView) and not any(
                 (obj is sfv) for sfv in res.stream_feature_views
@@ -175,7 +179,9 @@ def parse_repo(repo_root: Path) -> RepoContents:
 
                 # Handle batch sources defined with feature views.
                 batch_source = obj.batch_source
-                if not any((_data_sources_equal(batch_source, ds)) for ds in res.data_sources):
+                if not any(
+                    (_data_sources_equal(batch_source, ds)) for ds in res.data_sources
+                ):
                     res.data_sources.append(batch_source)
 
                 # Handle stream sources defined with feature views.
@@ -190,7 +196,9 @@ def parse_repo(repo_root: Path) -> RepoContents:
 
                 # Handle batch sources defined with feature views.
                 batch_source = obj.batch_source
-                if not any((_data_sources_equal(batch_source, ds)) for ds in res.data_sources):
+                if not any(
+                    (_data_sources_equal(batch_source, ds)) for ds in res.data_sources
+                ):
                     res.data_sources.append(batch_source)
             elif isinstance(obj, Entity) and not any(
                 (obj is entity) for entity in res.entities


### PR DESCRIPTION
Removed bq table delete for temp tables which contain the entities requested for historical retrieval at https://github.com/Ki-Insurance/feast/blob/master/sdk/python/feast/infra/offline_stores/bigquery.py#L290

This is only a fallback as these temp tables are due to expire in 30m anyway as we can see here https://github.com/Ki-Insurance/feast/blob/master/sdk/python/feast/infra/offline_stores/bigquery.py#L711

We're trying to get the SQL query that feast uses to retrieve the historical features (PR at https://github.com/Ki-Insurance/feature-store-connector/pull/516) so that we can run it client-side in the feature store connector client.

Since the creation of this SQL query is wrapped in a context manager here https://github.com/Ki-Insurance/feast/blob/master/sdk/python/feast/infra/offline_stores/bigquery.py#L253 , when we execute the query client-side the table has been already removed.

This change removes the fallback (virtually no extra risk as they expire anyway and names are uuid unique) and allows us to use that temp table later on after the call to feast 'server' has completed.

There are some failing tests which have to do with registry validation, they seem unrelated and they currently fail on main. I'm tempted to merge anyway and fix at a later date.
![image](https://github.com/user-attachments/assets/85e500e6-84ad-4d26-937e-fb1418cefca3)

