### PR TITLE
MOPS-608: Add InvalidEntityDataError for better entity validation errors

### DIFF
--- a/sdk/python/feast/errors.py
+++ b/sdk/python/feast/errors.py
@@ -427,3 +427,16 @@ class DataFrameSerializationError(Exception):
         super().__init__(
             f"Failed to serialize the provided dictionary into a pandas DataFrame: {input_dict.keys()}"
         )
+
+
+class InvalidEntityDataError(Exception):
+    """Raised when entity data provided to a feature retrieval request is invalid.
+
+    This includes cases like:
+    - Entity key doesn't match the required keys for the feature view
+    - Entity value has wrong type for the expected entity schema
+    - No valid entity keys were provided for the requested feature views
+    """
+
+    def __init__(self, message: str):
+        super().__init__(message)

--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -36,6 +36,7 @@ import numpy as np
 import pandas as pd
 from google.protobuf.timestamp_pb2 import Timestamp
 
+from feast.errors import InvalidEntityDataError
 from feast.protos.feast.types.Value_pb2 import (
     BoolList,
     BytesList,
@@ -46,7 +47,6 @@ from feast.protos.feast.types.Value_pb2 import (
     StringList,
 )
 from feast.protos.feast.types.Value_pb2 import Value as ProtoValue
-from feast.errors import InvalidEntityDataError
 from feast.value_type import ListType, ValueType
 
 if TYPE_CHECKING:


### PR DESCRIPTION
- Adds `InvalidEntityDataError` exception for entity validation failures in online feature requests
- Previously these returned cryptic errors AssertionError, ValueError, KeyError etc
- Now raises clear semantically meaningful errors that downstream services (i.e. feature-store-connector) can catch and surface to users

n.b. there will be a follow up PR in feature-store-connector to take advantage of these which will allow the following improvements:

| Scenario | Before | After |
|----------|--------|-------|
| Entity key doesn't exist in project | 500 | 400 ✅ |
| Entity key exists but wrong for feature view | 500 | 400 ✅ |
| Wrong entity value type | 500 | 400 ✅ |
| Partial composite key (missing required keys) | 200 (null) | 400 ✅ |

## Example error messages

```
Entity totally_wrong_key does not exist in project ki_feature_store
```

```
None of the provided entity keys ['prior_policy_ref'] match the required 
entity keys ['companyid', 'calendaryear', 'calendarmonth'] for feature view 'company_market_cap_fv_v2'
```

```
Missing required entity keys ['calendaryear', 'calendarmonth'] for feature view 'company_market_cap_fv_v2'. 
Provided: ['companyid'], Required: ['companyid', 'calendaryear', 'calendarmonth']
```

```
Failed to convert entity value 'not_a_number' to ValueType.INT64: invalid literal for int() with base 10: 'not_a_number'
```